### PR TITLE
Fix player cards wrapping

### DIFF
--- a/src/components/cards/PlayerCard/PlayerCard.module.css
+++ b/src/components/cards/PlayerCard/PlayerCard.module.css
@@ -6,6 +6,7 @@
   max-width: 100%;
   padding: 1rem 1rem 0 1rem;
   overflow: hidden;
+  height: 100%;
 }
 
 .image {

--- a/src/components/lists/PlayersList/PlayersList.module.css
+++ b/src/components/lists/PlayersList/PlayersList.module.css
@@ -1,7 +1,7 @@
 .container {
   column-gap: 4rem;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(20vw, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(310px, 1fr));
   margin-top: 2rem;
   max-width: 100%;
   row-gap: 4rem;


### PR DESCRIPTION
Fixing minimum width for all cards (in order to prevent content overflow) and cards height to make them look homogeneous (fixes #5) 
![Cattura](https://user-images.githubusercontent.com/44784095/138569703-c716dcee-4274-428f-8785-24105f303fe2.PNG)
